### PR TITLE
Reference counting for entities

### DIFF
--- a/Entitas/Entitas/Entity.cs
+++ b/Entitas/Entitas/Entity.cs
@@ -224,5 +224,37 @@ namespace Entitas {
             return obj._creationIndex;
         }
     }
+
+    public partial class Entity {
+        public event EntityReleased OnEntityReleased;
+        public delegate void EntityReleased(Entity entity);
+        
+        internal int _refCount = 0;
+
+        public Entity Retain(){
+            _refCount++;
+            return this;
+        }
+
+        public void Release(){
+            _refCount--;
+            if(_refCount == 0 && OnEntityReleased != null){
+                OnEntityReleased(this);
+            }
+            if(_refCount<0){
+                throw new EntityIsAlreadyReleasedException();
+            }
+        }
+
+        public void ResetRefCount(){
+            _refCount = 0;
+        }
+    }
+
+    public class EntityIsAlreadyReleasedException : Exception {
+        public EntityIsAlreadyReleasedException() :
+            base("Entity is already released!") {
+        }
+    }
 }
 

--- a/Entitas/Entitas/Group.cs
+++ b/Entitas/Entitas/Group.cs
@@ -58,6 +58,7 @@ namespace Entitas {
             if (added) {
                 _entitiesCache = null;
                 _singleEntityCache = null;
+                entity.Retain();
             }
         }
 
@@ -66,6 +67,7 @@ namespace Entitas {
             if (added) {
                 _entitiesCache = null;
                 _singleEntityCache = null;
+                entity.Retain();
                 if (OnEntityAdded != null) {
                     OnEntityAdded(this, entity, index, component);
                 }
@@ -77,6 +79,7 @@ namespace Entitas {
             if (removed) {
                 _entitiesCache = null;
                 _singleEntityCache = null;
+                entity.Release();
             }
         }
 
@@ -88,6 +91,7 @@ namespace Entitas {
                 if (OnEntityRemoved != null) {
                     OnEntityRemoved(this, entity, index, component);
                 }
+                entity.Release();
             }
         }
 

--- a/Entitas/Entitas/GroupObserver.cs
+++ b/Entitas/Entitas/GroupObserver.cs
@@ -55,16 +55,20 @@ namespace Entitas {
                 var group = _groups[i];
                 group.OnEntityAdded -= addEntity;
                 group.OnEntityRemoved -= addEntity;
-                _collectedEntities.Clear();
             }
+            ClearCollectedEntities();
         }
 
         public void ClearCollectedEntities() {
+            foreach (var entity in _collectedEntities) {
+                entity.Release();
+            }
             _collectedEntities.Clear();
         }
 
         void addEntity(Group group, Entity entity, int index, IComponent component) {
             _collectedEntities.Add(entity);
+            entity.Retain();
         }
     }
 

--- a/Entitas/Entitas/ReactiveSystem.cs
+++ b/Entitas/Entitas/ReactiveSystem.cs
@@ -75,11 +75,11 @@ namespace Entitas {
                     _buffer.AddRange(_observer.collectedEntities);
                 }
 
-                _observer.ClearCollectedEntities();
                 if (_buffer.Count != 0) {
                     _subsystem.Execute(_buffer);
                     _buffer.Clear();
                 }
+                _observer.ClearCollectedEntities();
             }
         }
     }

--- a/Tests/Tests/Entitas/describe_Entity.cs
+++ b/Tests/Tests/Entitas/describe_Entity.cs
@@ -218,6 +218,29 @@ class describe_Entity : nspec {
             };
         };
 
+        context["reference counting"] = () => {
+            it["dispatches OnEntityReleased when retain and release"] = () => {
+                Entity eventEntity = null;
+                e.OnEntityReleased += (entity) => {
+                    eventEntity = entity;
+                };
+                e.Retain();
+                e.Release();
+                eventEntity.should_be_same(e);
+            };
+
+            it["does not dipatch and does not throw, when OnEntityReleased is not set"] = () => {
+                e.Retain();
+                e.Release();
+            };
+
+            it["throws when releasing more than it has been retained"] = expect<EntityIsAlreadyReleasedException>(() => {
+                e.Retain();
+                e.Release();
+                e.Release();
+            });
+        };
+
         context["invalid operations"] = () => {
             it["throws when adding a component of the same type twice"] = expect<EntityAlreadyHasComponentException>(() => {
                 e.AddComponentA();

--- a/Tests/Tests/Entitas/describe_Group.cs
+++ b/Tests/Tests/Entitas/describe_Group.cs
@@ -200,6 +200,17 @@ class describe_Group : nspec {
             };
         };
 
+        it["counts entity reference up on entity added and down on entity removed"] = () => {
+            Entity eventEntity = null;
+            _eA1.OnEntityReleased += (entity) => {
+                eventEntity = entity;
+            };
+            handle(_eA1);
+            _eA1.RemoveComponentA();
+            handle(_eA1);
+            eventEntity.should_be_same(_eA1);
+        };
+
         it["can ToString"] = () => {
             var m = Matcher.AllOf(Matcher.AllOf(0), Matcher.AllOf(1));
             var group = new Group(m);

--- a/Tests/Tests/Entitas/describe_GroupObserver.cs
+++ b/Tests/Tests/Entitas/describe_GroupObserver.cs
@@ -92,27 +92,25 @@ class describe_GroupObserver : nspec {
                 observer.collectedEntities.should_be_empty();
             };
             
-            it["counts entity reference up when collecting"] = () => {
-                var e = pool.CreateEntity();
-                e.AddComponentA();
-                e.OnEntityReleased += (entity) => this.Fail();
-                e.RemoveComponentA();
-            };
-            
-            it["counts entity reference down when clearing"] = () => {
-                Entity eventEntity = null;
-                var e = pool.CreateEntity();
-                e.ResetRefCount();
-                e.OnEntityReleased += (entity) => {
-                    eventEntity = entity;
+            context["reference counting"] = () => {
+                it["keeps reference count of an entity at one even after destroy"] = () => {
+                    var e = pool.CreateEntity();
+                    e.AddComponentA();
+                    e.OnEntityReleased += (entity) => this.Fail();
+                    pool.DestroyEntity(e);
                 };
-                e.AddComponentA();
-                e.RemoveComponentA();
-                observer.ClearCollectedEntities();
-                eventEntity.should_be_same(e);
+                
+                it["counts entity reference down when clearing"] = () => {
+                    Entity eventEntity = null;
+                    var e = pool.CreateEntity();
+                    e.OnEntityReleased += (entity) => {
+                        eventEntity = entity;
+                    };
+                    pool.DestroyEntity(e);
+                    observer.ClearCollectedEntities();
+                    eventEntity.should_be_same(e);
+                };
             };
-
-            
         };
 
         context["when observing with eventType OnEntityRemoved"] = () => {

--- a/Tests/Tests/Entitas/describe_GroupObserver.cs
+++ b/Tests/Tests/Entitas/describe_GroupObserver.cs
@@ -91,6 +91,28 @@ class describe_GroupObserver : nspec {
                 observer.ClearCollectedEntities();
                 observer.collectedEntities.should_be_empty();
             };
+            
+            it["counts entity reference up when collecting"] = () => {
+                var e = pool.CreateEntity();
+                e.AddComponentA();
+                e.OnEntityReleased += (entity) => this.Fail();
+                e.RemoveComponentA();
+            };
+            
+            it["counts entity reference down when clearing"] = () => {
+                Entity eventEntity = null;
+                var e = pool.CreateEntity();
+                e.ResetRefCount();
+                e.OnEntityReleased += (entity) => {
+                    eventEntity = entity;
+                };
+                e.AddComponentA();
+                e.RemoveComponentA();
+                observer.ClearCollectedEntities();
+                eventEntity.should_be_same(e);
+            };
+
+            
         };
 
         context["when observing with eventType OnEntityRemoved"] = () => {

--- a/Tests/Tests/Entitas/describe_Pool.cs
+++ b/Tests/Tests/Entitas/describe_Pool.cs
@@ -160,16 +160,27 @@ class describe_Pool : nspec {
                 e.HasComponent(CID.ComponentA).should_be_false();
             };
 
-            xit["returns pushed entity"] = () => {
-
-                // #if (ENTITAS_ENTITY_OBJECT_POOL)
-
+            it["returns pushed entity"] = () => {
                 var e = _pool.CreateEntity();
                 e.AddComponentA();
                 _pool.DestroyEntity(e);
                 var entity = _pool.CreateEntity();
                 entity.HasComponent(CID.ComponentA).should_be_false();
                 entity.should_be_same(e);
+            };
+
+            it["returns pushed entity only after observer is cleared"] = () => {
+                var e = _pool.CreateEntity();
+                var groupA = _pool.GetGroup(Matcher.AllOf(new [] { CID.ComponentA }));
+                var observer = new GroupObserver(groupA, GroupEventType.OnEntityAdded);
+                e.AddComponentA();
+                _pool.DestroyEntity(e);
+                var entity = _pool.CreateEntity();
+                entity.HasComponent(CID.ComponentA).should_be_false();
+                entity.should_not_be_same(e);
+                observer.ClearCollectedEntities();
+                var entity2 = _pool.CreateEntity();
+                entity2.should_be_same(e);
             };
 
             it["returns new entity"] = () => {


### PR DESCRIPTION
A destroyed entity can be reused only after it's reference count reaches zero.
Therefor we can use entity object pool again per default.