### PR TITLE
Added documentation on the lifecycle of the Entity, Group and Pool.

### DIFF
--- a/Entitas/Entitas/Group.cs
+++ b/Entitas/Entitas/Group.cs
@@ -65,12 +65,8 @@ namespace Entitas {
         }
 
         /// <summary>
-        /// Called whenever
+        /// Called whenever a Component is replaced on an Entity.
         /// </summary>
-        /// <param name="entity"></param>
-        /// <param name="index"></param>
-        /// <param name="previousComponent"></param>
-        /// <param name="newComponent"></param>
         public void UpdateEntity(Entity entity, int index, IComponent previousComponent, IComponent newComponent) {
             if (_entities.Contains(entity)) {
                 if (OnEntityRemoved != null) {

--- a/Entitas/Entitas/Group.cs
+++ b/Entitas/Entitas/Group.cs
@@ -1,10 +1,30 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace Entitas {
+
+    /// <summary>
+    /// Represents a Group of Entities defined by a <see cref="IMatcher"/>.
+    /// Responsible for maintaining a list of entities conforming to that <see cref="IMatcher"/> and the events surrounding it as defined by <see cref="OnEntityAdded"/>, <see cref="OnEntityRemoved"/> and <see cref="OnEntityUpdated"/>.
+    /// </summary>
     public class Group {
-        public event GroupChanged OnEntityAdded;
+
+        /// <summary>
+        /// Called whenever an Entity is removed from the group, or a Component to which this Group is subscribed on an Entity is changed. <para/>
+        /// Upon change, the event is called with the old Component, and called before <see cref="OnEntityAdded"/> and <see cref="OnEntityUpdated"/>.
+        /// </summary>
         public event GroupChanged OnEntityRemoved;
+
+        /// <summary>
+        /// Called whenever an Entity is added to the group, or a Component to which this Group is subscribed on an Entity is changed. <para/>
+        /// Upon change, the event is called with the new Component, and called before <see cref="OnEntityUpdated"/>, but after <see cref="OnEntityRemoved"/>.
+        /// </summary>
+        public event GroupChanged OnEntityAdded;
+
+        /// <summary>
+        /// Called whenever an Entity in this group is updated (i.e.; has its Component replaced).
+        /// This event is called after <see cref="OnEntityRemoved"/> and <see cref="OnEntityAdded"/>
+        /// </summary>
         public event GroupUpdated OnEntityUpdated;
 
         public delegate void GroupChanged(Group group, Entity entity, int index, IComponent component);
@@ -33,6 +53,9 @@ namespace Entitas {
             }
         }
 
+        /// <summary>
+        /// Called whenever a Component is removed or added to an Entity and will add or remove the Entity from the Group. 
+        /// </summary>
         public void HandleEntity(Entity entity, int index, IComponent component) {
             if (_matcher.Matches(entity)) {
                 addEntity(entity, index, component);
@@ -41,6 +64,13 @@ namespace Entitas {
             }
         }
 
+        /// <summary>
+        /// Called whenever
+        /// </summary>
+        /// <param name="entity"></param>
+        /// <param name="index"></param>
+        /// <param name="previousComponent"></param>
+        /// <param name="newComponent"></param>
         public void UpdateEntity(Entity entity, int index, IComponent previousComponent, IComponent newComponent) {
             if (_entities.Contains(entity)) {
                 if (OnEntityRemoved != null) {

--- a/Entitas/Entitas/Pool.cs
+++ b/Entitas/Entitas/Pool.cs
@@ -1,7 +1,12 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace Entitas {
+
+    /// <summary>
+    /// The pool is the central API by which to control the lifecycle of <see cref="Entity"/> and <see cref="Group"/>, and serves as a cache for both to avoid unnecessary creation.
+    /// The Entity lifecycle is managed by <see cref="CreateEntity"/> and <see cref="DestroyEntity"/>. 
+    /// </summary>
     public partial class Pool {
 
         public event PoolChanged OnEntityCreated;
@@ -65,6 +70,10 @@ namespace Entitas {
             return entity;
         }
 
+        /// <summary>
+        /// API to destroy an entity. 
+        /// <see cref="Entity.destroy"/> 
+        /// </summary>
         public virtual void DestroyEntity(Entity entity) {
             var removed = _entities.Remove(entity);
             if (!removed) {
@@ -112,6 +121,9 @@ namespace Entitas {
             return _entitiesCache;
         }
 
+        /// <summary>
+        /// Creates a Group for the given matcher and caches the result internally for subsequent calls.
+        /// </summary>
         public virtual Group GetGroup(IMatcher matcher) {
             Group group;
             if (!_groups.TryGetValue(matcher, out group)) {


### PR DESCRIPTION
The difference in lifecycle between how an Entity calls events surrounding Added/Update/Remove, and the Group calls these similar types of events lead to some headscratches so I thought to document them a bit.

Adds in documentation on Destroy, warning the user to look at Pool.