### PR TITLE
Exclude scripts only needed in editor from build

### DIFF
--- a/Entitas.CodeGenerator/Entitas.CodeGenerator/CodeGenFile.cs
+++ b/Entitas.CodeGenerator/Entitas.CodeGenerator/CodeGenFile.cs
@@ -1,7 +1,8 @@
-﻿namespace Entitas.CodeGenerator {
+#if UNITY_EDITOR
+namespace Entitas.CodeGenerator {
     public struct CodeGenFile {
         public string fileName;
         public string fileContent;
     }
 }
-
+#endif

--- a/Entitas.CodeGenerator/Entitas.CodeGenerator/CodeGenerator.cs
+++ b/Entitas.CodeGenerator/Entitas.CodeGenerator/CodeGenerator.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -123,3 +124,4 @@ namespace Entitas.CodeGenerator {
         }
     }
 }
+#endif

--- a/Entitas.CodeGenerator/Entitas.CodeGenerator/Generators/ComponentExtensionsGenerator.cs
+++ b/Entitas.CodeGenerator/Entitas.CodeGenerator/Generators/ComponentExtensionsGenerator.cs
@@ -1,4 +1,5 @@
-﻿using System;
+#if UNITY_EDITOR
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -383,4 +384,4 @@ $assign
         public Type type;
     }
 }
-
+#endif

--- a/Entitas.CodeGenerator/Entitas.CodeGenerator/Generators/IndicesLookupGenerator.cs
+++ b/Entitas.CodeGenerator/Entitas.CodeGenerator/Generators/IndicesLookupGenerator.cs
@@ -1,4 +1,5 @@
-﻿using System;
+#if UNITY_EDITOR
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -170,3 +171,4 @@ public partial class {0}Matcher : AllOfMatcher {{
         }
     }
 }
+#endif

--- a/Entitas.CodeGenerator/Entitas.CodeGenerator/Generators/PoolAttributeGenerator.cs
+++ b/Entitas.CodeGenerator/Entitas.CodeGenerator/Generators/PoolAttributeGenerator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+#if UNITY_EDITOR
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Entitas.CodeGenerator {
@@ -26,4 +27,4 @@ public class {0}Attribute : PoolAttribute {{
         }
     }
 }
-
+#endif

--- a/Entitas.CodeGenerator/Entitas.CodeGenerator/Generators/PoolsGenerator.cs
+++ b/Entitas.CodeGenerator/Entitas.CodeGenerator/Generators/PoolsGenerator.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+#if UNITY_EDITOR
+using System.Linq;
 using Entitas.CodeGenerator;
 
 namespace Entitas.CodeGenerator {
@@ -62,3 +63,4 @@ public static class Pools {{{0}{1}
         }
     }
 }
+#endif

--- a/Entitas.CodeGenerator/Entitas.CodeGenerator/Generators/SystemExtensionsGenerator.cs
+++ b/Entitas.CodeGenerator/Entitas.CodeGenerator/Generators/SystemExtensionsGenerator.cs
@@ -1,4 +1,5 @@
-﻿using System;
+#if UNITY_EDITOR
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Entitas.CodeGenerator;
@@ -30,3 +31,4 @@ namespace Entitas.CodeGenerator {
         }
     }
 }
+#endif

--- a/Entitas.CodeGenerator/Entitas.CodeGenerator/Generators/TypeGenerator.cs
+++ b/Entitas.CodeGenerator/Entitas.CodeGenerator/Generators/TypeGenerator.cs
@@ -1,4 +1,5 @@
-﻿using System;
+#if UNITY_EDITOR
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -58,3 +59,4 @@ namespace Entitas.CodeGenerator {
         }
     }
 }
+#endif

--- a/Entitas.CodeGenerator/Entitas.CodeGenerator/ICodeGenerator.cs
+++ b/Entitas.CodeGenerator/Entitas.CodeGenerator/ICodeGenerator.cs
@@ -1,5 +1,7 @@
-﻿namespace Entitas.CodeGenerator {
+#if UNITY_EDITOR
+namespace Entitas.CodeGenerator {
     public interface ICodeGenerator {
     }
 }
+#endif
 

--- a/Entitas.CodeGenerator/Entitas.CodeGenerator/IComponentCodeGenerator.cs
+++ b/Entitas.CodeGenerator/Entitas.CodeGenerator/IComponentCodeGenerator.cs
@@ -1,8 +1,9 @@
-﻿using System;
+#if UNITY_EDITOR
+using System;
 
 namespace Entitas.CodeGenerator {
     public interface IComponentCodeGenerator : ICodeGenerator {
         CodeGenFile[] Generate(Type[] components);
     }
 }
-
+#endif

--- a/Entitas.CodeGenerator/Entitas.CodeGenerator/IPoolCodeGenerator.cs
+++ b/Entitas.CodeGenerator/Entitas.CodeGenerator/IPoolCodeGenerator.cs
@@ -1,6 +1,7 @@
-﻿namespace Entitas.CodeGenerator {
+#if UNITY_EDITOR
+namespace Entitas.CodeGenerator {
     public interface IPoolCodeGenerator : ICodeGenerator {
         CodeGenFile[] Generate(string[] poolNames);
     }
 }
-
+#endif

--- a/Entitas.CodeGenerator/Entitas.CodeGenerator/ISystemCodeGenerator.cs
+++ b/Entitas.CodeGenerator/Entitas.CodeGenerator/ISystemCodeGenerator.cs
@@ -1,8 +1,9 @@
-﻿using System;
+#if UNITY_EDITOR
+using System;
 
 namespace Entitas.CodeGenerator {
     public interface ISystemCodeGenerator : ICodeGenerator {
         CodeGenFile[] Generate(Type[] systems);
     }
 }
-
+#endif


### PR DESCRIPTION
I had the problem that Windows Store App builds with Unity didn't work because they were problems with scripts that are only needed in the editor. I used "#if UNITY_EDITOR" to exclude those scripts from the build, Windows Store App builds work now. Another advantage is a small build size reduction.

If I have excluded something that is needed at runtime or there are more scripts that could be excluded from the build, please change that.