### PR TITLE
Platform-independent path separators in namespace and migration tests

### DIFF
--- a/Tests/Tests/Entitas.Migration/describe_M0180.cs
+++ b/Tests/Tests/Entitas.Migration/describe_M0180.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using Entitas.Migration;
 using NSpec;
@@ -17,9 +18,9 @@ class describe_M0180 : nspec {
         it["finds all reactive system"] = () => {
             var updatedFiles = m.Migrate(dir);
             updatedFiles.Length.should_be(3);
-            updatedFiles.Any(file => file.fileName == dir + "/RenderPositionSystem.cs").should_be_true();
-            updatedFiles.Any(file => file.fileName == dir + "/RenderRotationSystem.cs").should_be_true();
-            updatedFiles.Any(file => file.fileName == dir + "/SubFolder/RenderSelectedSystem.cs").should_be_true();
+            updatedFiles.Any(file => file.fileName == Path.Combine(dir, "RenderPositionSystem.cs")).should_be_true();
+            updatedFiles.Any(file => file.fileName == Path.Combine(dir, "RenderRotationSystem.cs")).should_be_true();
+            updatedFiles.Any(file => file.fileName == Path.Combine(dir, Path.Combine("SubFolder", "RenderSelectedSystem.cs"))).should_be_true();
         };
 
         it["migrates to new api"] = () => {
@@ -28,7 +29,7 @@ class describe_M0180 : nspec {
 //                Console.WriteLine(file.fileContent);
             }
 
-            var reactiveSystemFile = updatedFiles.Where(file => file.fileName == dir + "/RenderRotationSystem.cs").First();
+            var reactiveSystemFile = updatedFiles.Where(file => file.fileName == Path.Combine(dir, "RenderRotationSystem.cs")).First();
             reactiveSystemFile.fileContent.should_be(@"using Entitas;
 
 public class RenderRotationSystem : IReactiveSystem

--- a/Tests/Tests/Entitas.Migration/describe_M0190.cs
+++ b/Tests/Tests/Entitas.Migration/describe_M0190.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using Entitas.Migration;
 using NSpec;
@@ -16,14 +17,14 @@ class describe_M0190 : nspec {
         it["finds all reactive system"] = () => {
             var updatedFiles = m.Migrate(dir);
             updatedFiles.Length.should_be(3);
-            updatedFiles.Any(file => file.fileName == dir + "/RenderPositionSystem.cs").should_be_true();
-            updatedFiles.Any(file => file.fileName == dir + "/RenderRotationSystem.cs").should_be_true();
-            updatedFiles.Any(file => file.fileName == dir + "/SubFolder/RenderSelectedSystem.cs").should_be_true();
+            updatedFiles.Any(file => file.fileName == Path.Combine(dir, "RenderPositionSystem.cs")).should_be_true();
+            updatedFiles.Any(file => file.fileName == Path.Combine(dir, "RenderRotationSystem.cs")).should_be_true();
+            updatedFiles.Any(file => file.fileName == Path.Combine(dir, Path.Combine("SubFolder", "RenderSelectedSystem.cs"))).should_be_true();
         };
 
         it["migrates to new api"] = () => {
             var updatedFiles = m.Migrate(dir);
-            var reactiveSystemFile = updatedFiles.Where(file => file.fileName == dir + "/RenderRotationSystem.cs").First();
+            var reactiveSystemFile = updatedFiles.Where(file => file.fileName == Path.Combine(dir, "RenderRotationSystem.cs")).First();
             reactiveSystemFile.fileContent.should_be(@"using Entitas;
 
 public class RenderRotationSystem : IReactiveSystem {

--- a/Tests/Tests/Entitas.Migration/describe_M0220.cs
+++ b/Tests/Tests/Entitas.Migration/describe_M0220.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using Entitas.Migration;
 using NSpec;
@@ -16,12 +17,12 @@ class describe_M0220 : nspec {
         it["finds all reactive system"] = () => {
             var updatedFiles = m.Migrate(dir);
             updatedFiles.Length.should_be(1);
-            updatedFiles.Any(file => file.fileName == dir + "/RenderPositionSystem.cs").should_be_true();
+            updatedFiles.Any(file => file.fileName == Path.Combine(dir, "RenderPositionSystem.cs")).should_be_true();
         };
 
         it["migrates to new api"] = () => {
             var updatedFiles = m.Migrate(dir);
-            var reactiveSystemFile = updatedFiles.Single(file => file.fileName == dir + "/RenderPositionSystem.cs");
+            var reactiveSystemFile = updatedFiles.Single(file => file.fileName == Path.Combine(dir, "RenderPositionSystem.cs"));
             reactiveSystemFile.fileContent.should_be(@"using System.Collections.Generic;
 using Entitas;
 

--- a/Tests/Tests/Entitas.Migration/describe_MigrationUtils.cs
+++ b/Tests/Tests/Entitas.Migration/describe_MigrationUtils.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using Entitas.Migration;
 using NSpec;
@@ -11,12 +12,12 @@ class describe_MigrationUtils : nspec {
         it["gets only *.cs source files"] = () => {
             var files = MigrationUtils.GetSourceFiles(dir);
             files.Length.should_be(6);
-            files.Any(file => file.fileName == dir + "/SourceFile.cs").should_be_true();
-            files.Any(file => file.fileName == dir + "/SubFolder/SourceFile2.cs").should_be_true();
-            files.Any(file => file.fileName == dir + "/RenderPositionSystem.cs").should_be_true();
-            files.Any(file => file.fileName == dir + "/RenderRotationSystem.cs").should_be_true();
-            files.Any(file => file.fileName == dir + "/SubFolder/RenderSelectedSystem.cs").should_be_true();
-            files.Any(file => file.fileName == dir + "/SubFolder/MoveSystem.cs").should_be_true();
+            files.Any(file => file.fileName == Path.Combine(dir, "SourceFile.cs")).should_be_true();
+            files.Any(file => file.fileName == Path.Combine(dir, Path.Combine("SubFolder", "SourceFile2.cs"))).should_be_true();
+            files.Any(file => file.fileName == Path.Combine(dir, "RenderPositionSystem.cs")).should_be_true();
+            files.Any(file => file.fileName == Path.Combine(dir, "RenderRotationSystem.cs")).should_be_true();
+            files.Any(file => file.fileName == Path.Combine(dir, Path.Combine("SubFolder", "RenderSelectedSystem.cs"))).should_be_true();
+            files.Any(file => file.fileName == Path.Combine(dir, Path.Combine("SubFolder", "MoveSystem.cs"))).should_be_true();
         };
     }
 }

--- a/Tests/Tests/check_namespaces.cs
+++ b/Tests/Tests/check_namespaces.cs
@@ -13,12 +13,12 @@ class check_namespaces : nspec {
 
     static Dictionary<string, string> getSourceFiles(string path) {
         return Directory.GetFiles(path, "*.cs", SearchOption.AllDirectories)
-            .Where(p => !p.Contains("Generated/") &&
-                !p.Contains("Libraries/") &&
-                !p.Contains("Tests/") &&
-                !p.Contains("Readme/") &&
-                !p.Contains("bin/") &&
-                !p.Contains("obj/") &&
+            .Where(p => !p.Contains("Generated" + Path.DirectorySeparatorChar) &&
+                !p.Contains("Libraries" + Path.DirectorySeparatorChar) &&
+                !p.Contains("Tests" + Path.DirectorySeparatorChar) &&
+                !p.Contains("Readme" + Path.DirectorySeparatorChar) &&
+                !p.Contains("bin" + Path.DirectorySeparatorChar) &&
+                !p.Contains("obj" + Path.DirectorySeparatorChar) &&
                 !p.Contains("AssemblyInfo.cs") &&
                 !p.Contains("Program.cs"))
             .ToDictionary(p => p, p => File.ReadAllText(p));
@@ -33,10 +33,10 @@ class check_namespaces : nspec {
             sourceFiles.Count.should_be_less_than(100);
 
             const string namespacePattern = @"(?:^namespace)\s.*\b";
-            const string expectedNamespacePattern = @".+?[^\/]*";
+            string expectedNamespacePattern = string.Format(@".+?[^\{0}]*", Path.DirectorySeparatorChar);
 
             foreach (var file in sourceFiles) {
-                var fileName = file.Key.Replace(entitasDir + "/", string.Empty);
+                var fileName = file.Key.Replace(entitasDir + Path.DirectorySeparatorChar, string.Empty);
                 var expectedNamespace = Regex.Match(fileName, expectedNamespacePattern)
                         .ToString()
                         .Replace("namespace ", string.Empty)


### PR DESCRIPTION
On Windows platforms, 8 out of 383 tests currently fail, due to Unix-style directory separators in string literals:

	**** FAILURES ****

	nspec. check namespaces. when running test. checks namespaces.
	Expected: less than 100, But was: 619
	   at check_namespaces.<>c.<when_running_test>b__2_0() in D:\Dev\SCM\Entitas-CSharp\Tests\Tests\check_namespaces.cs:line 33

	nspec. describe MigrationUtils. when migrating. gets only *.cs source files.
	Expected: True, But was: False
	   at describe_MigrationUtils.<>c__DisplayClass0_0.<when_migrating>b__0() in D:\Dev\SCM\Entitas-CSharp\Tests\Tests\Entitas.Migration\describe_MigrationUtils.cs:li
	ne 14

	nspec. describe M0180. when migration. finds all reactive system.
	Expected: True, But was: False
	   at describe_M0180.<>c__DisplayClass0_0.<when_migration>b__1() in D:\Dev\SCM\Entitas-CSharp\Tests\Tests\Entitas.Migration\describe_M0180.cs:line 20

	nspec. describe M0180. when migration. migrates to new api.
	Sequence contains no elements
	   at System.Linq.Enumerable.First[TSource](IEnumerable`1 source)
	   at describe_M0180.<>c__DisplayClass0_0.<when_migration>b__5() in D:\Dev\SCM\Entitas-CSharp\Tests\Tests\Entitas.Migration\describe_M0180.cs:line 31

	nspec. describe M0190. when migrating. finds all reactive system.
	Expected: True, But was: False
	   at describe_M0190.<>c__DisplayClass0_0.<when_migrating>b__1() in D:\Dev\SCM\Entitas-CSharp\Tests\Tests\Entitas.Migration\describe_M0190.cs:line 19

	nspec. describe M0190. when migrating. migrates to new api.
	Sequence contains no elements
	   at System.Linq.Enumerable.First[TSource](IEnumerable`1 source)
	   at describe_M0190.<>c__DisplayClass0_0.<when_migrating>b__5() in D:\Dev\SCM\Entitas-CSharp\Tests\Tests\Entitas.Migration\describe_M0190.cs:line 26

	nspec. describe M0220. when migrating. finds all reactive system.
	Expected: True, But was: False
	   at describe_M0220.<>c__DisplayClass0_0.<when_migrating>b__1() in D:\Dev\SCM\Entitas-CSharp\Tests\Tests\Entitas.Migration\describe_M0220.cs:line 19

	nspec. describe M0220. when migrating. migrates to new api.
	Sequence contains no matching element
	   at System.Linq.Enumerable.Single[TSource](IEnumerable`1 source, Func`2 predicate)
	   at describe_M0220.<>c__DisplayClass0_0.<when_migrating>b__3() in D:\Dev\SCM\Entitas-CSharp\Tests\Tests\Entitas.Migration\describe_M0220.cs:line 24

This can easily be fixed by using Path.DirectorySeparatorChar and Path.Combine in the respective tests.