### PR TITLE
Automatically building tests before running on Windows

### DIFF
--- a/runTests.bat
+++ b/runTests.bat
@@ -1,1 +1,21 @@
-Tests\Libraries\NSpec\NSpecRunner.exe Tests\bin\Debug\Tests.dll
+@ECHO OFF
+
+REM Find MSBuild.
+REM by yoyo: http://stackoverflow.com/a/13752506/1700174
+FOR /D %%D in (%SYSTEMROOT%\Microsoft.NET\Framework\v4*) DO SET msbuild.exe=%%D\MSBuild.exe
+
+IF NOT EXIST "%msbuild.exe%" (
+	ECHO Error: MSBuild not found. Could not compile tests.
+	EXIT /B 1
+)
+
+REM Compile tests.
+CALL %msbuild.exe% Tests\Tests.csproj /property:Configuration=Debug
+
+IF NOT %ERRORLEVEL% == 0 (
+	ECHO Error %ERRORLEVEL%: Could not compile tests.
+	EXIT /B %ERRORLEVEL%
+)
+
+REM Run tests.
+Tests\Libraries\NSpec\NSpecRunner.exe Tests\bin\Debug\Tests.dll	


### PR DESCRIPTION
This is achieved through running msbuild on Windows, just like xbuild on UNIX platforms.

Unfortunately, msbuild happens not to be part of the path more often than not, so we're trying to discover its location before.