### PR TITLE
Feature Request: abstract WrapperComponent class

### DIFF
--- a/Entitas/Entitas/CodeGenerator/Providers/TypeReflectionProvider.cs
+++ b/Entitas/Entitas/CodeGenerator/Providers/TypeReflectionProvider.cs
@@ -20,6 +20,7 @@ namespace Entitas.CodeGenerator {
         public static ComponentInfo[] GetComponentInfos(Type[] types) {
             return types
                 .Where(type => !type.IsInterface)
+                .Where(type => !type.IsAbstract)
                 .Where(type => type.GetInterfaces().Any(i => i.FullName == "Entitas.IComponent"))
                 .Select(type => CreateComponentInfo(type))
                 .ToArray();

--- a/Entitas/Entitas/WrapperComponent.cs
+++ b/Entitas/Entitas/WrapperComponent.cs
@@ -1,0 +1,23 @@
+﻿namespace Entitas {
+
+    /// Inherit from this class if you want a component that is just a wrapper for some type.
+    /// All attributes that work for normal components also work for components that inherit from this class.
+    /// The body of the inheriting class should remain empty.
+    /// Example use:
+    /// <example>
+    ///     // definition
+    ///     public class NameComponent : WrapperComponent&lt;string&gt; { }
+    ///     
+    ///     // usage (after generator has run)
+    ///     public string PhoneNumber(Entity e, Dictionary&lt;string, string&gt; phoneBook) {
+    ///         if(e.Name == "Bob") { return "012 333 4545"; }
+    ///
+    ///         return phoneBook[e.Name];
+    ///     }
+    /// </example>
+    public abstract class WrapperComponent<T> : IComponent {
+        public T value;
+
+        public static implicit operator T(WrapperComponent<T> component) { return component.value; }
+    }
+}


### PR DESCRIPTION
In many cases, all a component has to do is hold just a single value.
Components of this type can feel a bit clunky, because you end up writing things like:
```
string name = entity.Name.value;
GameObject object = entity.GameObject.value;
int score += entity.PointValue.value;
```

The code becomes more concise when an implicit conversion operator is added to these Components:
```
string name = entity.Name; //implicitly converted to string
GameObject object = entity.GameObject; //implicitly converted to GameObject
int score += entity.PointValue;  //implicitly converted to int
```

I added the abstract WrapperComponent class to allow users to create these single value Components including the implicit conversion operator in a single line of code:
```
public class NameComponent: WrapperComponent<string> { }
```

This line of code is equivalent to the following:
```
public class NameComponent: IComponent
{
  public T value;

  public static implicit operator string(NameComponent component) 
  {
    return component.value;
  }
}
```