### PR TITLE
Fix Destroy compile time error

### DIFF
--- a/Entitas.Unity/Assets/Entitas/Unity/VisualDebugging/GameObjectDestroyExtension.cs
+++ b/Entitas.Unity/Assets/Entitas/Unity/VisualDebugging/GameObjectDestroyExtension.cs
@@ -16,7 +16,7 @@ namespace Entitas.Unity.VisualDebugging {
 
             #else
 
-        Destroy(gameObject);
+            Object.Destroy(gameObject);
 
             #endif
         }


### PR DESCRIPTION
Project refused to build post upgrade to 0.30.0.

Error:
error CS0103: The name `Destroy' does not exist in the current context