### PR TITLE
Fix IndexOutOfRangeException

### DIFF
--- a/Entitas.Unity/Assets/Entitas/Unity/Editor/EntitasEditorLayout.cs
+++ b/Entitas.Unity/Assets/Entitas/Unity/Editor/EntitasEditorLayout.cs
@@ -11,10 +11,13 @@ namespace Entitas.Unity {
         }
 
         public static Texture2D LoadTexture(string label) {
-            var guid = AssetDatabase.FindAssets(label)[0];
-            if (guid != null) {
-                var path = AssetDatabase.GUIDToAssetPath(guid);
-                return AssetDatabase.LoadAssetAtPath<Texture2D>(path);
+            var assets = AssetDatabase.FindAssets(label);
+            if (assets.Length > 0) {
+                var guid = assets[0];
+                if (guid != null) {
+                    var path = AssetDatabase.GUIDToAssetPath(guid);
+                    return AssetDatabase.LoadAssetAtPath<Texture2D>(path);
+                }
             }
             return null;
         }


### PR DESCRIPTION
If no assets are found in the AssetDatabase this fixes an IndexOutOfRangeException.

This was a happening randomly in my game, full stacktrace:

>IndexOutOfRangeException: Array index is out of range.
Entitas.Unity.EntitasEditorLayout.LoadTexture (System.String label)
Entitas.Unity.VisualDebugging.EntitasHierarchyIcon.get_poolErrorHierarchyIcon ()
Entitas.Unity.VisualDebugging.EntitasHierarchyIcon.onHierarchyWindowItemOnGUI (Int32 instanceID, Rect selectionRect)
UnityEditor.SceneHierarchyWindow.OnGUIAssetCallback (Int32 instanceID, Rect rect)
UnityEditor.TreeView.DoItemGUI (UnityEditor.TreeViewItem item, Int32 row, Single rowWidth, Boolean hasFocus)
UnityEditor.TreeView.IterateVisibleItems (Int32 firstRow, Int32 numVisibleRows, Single rowWidth, Boolean hasFocus)
UnityEditor.TreeView.OnGUI (Rect rect, Int32 keyboardControlID)
UnityEditor.SceneHierarchyWindow.DoTreeView (Single searchPathHeight)
UnityEditor.SceneHierarchyWindow.OnGUI ()
System.Reflection.MonoMethod.Invoke (System.Object obj, BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture)