### PR TITLE
Fix error when turning visual debugging on/off in Unity 5.4 or newer

### DIFF
--- a/Entitas.Unity/Assets/Entitas/Unity/Editor/ScriptingDefineSymbols.cs
+++ b/Entitas.Unity/Assets/Entitas/Unity/Editor/ScriptingDefineSymbols.cs
@@ -15,6 +15,7 @@ namespace Entitas.Unity {
             _buildTargetToDefSymbol = Enum.GetValues(typeof(BuildTargetGroup))
                 .Cast<BuildTargetGroup>()
                 .Where(buildTargetGroup => buildTargetGroup != BuildTargetGroup.Unknown)
+                .Where(buildTargetGroup => !isBuildTargetObsolete(buildTargetGroup))
                 .Distinct()
                     .ToDictionary(
                     buildTargetGroup => buildTargetGroup,
@@ -36,6 +37,12 @@ namespace Entitas.Unity {
                     kv.Key, kv.Value.Replace(defineSymbol, string.Empty)
                 );
             }
+        }
+
+        bool isBuildTargetObsolete(BuildTargetGroup value) {
+            var fieldInfo = value.GetType().GetField(value.ToString());
+            var attributes = (ObsoleteAttribute[])fieldInfo.GetCustomAttributes(typeof(ObsoleteAttribute), false);
+            return (attributes != null && attributes.Length > 0);
         }
     }
 }


### PR DESCRIPTION
In Unity 5.4, Unity added the Obsolete attribute to the WP8 and BlackBerry values in the UnityEditor.BuildTargetGroup enum and removed them as valid build targets for scripting defines.

This means that when you try and change the toggle value for the Enable Visual Debugging setting, you get the following 2 errors in the console:
1. `PlayerSettings Validation: Requested build target group (15) doesn't exist; #define symbols for scripting won't be added.`
2. `PlayerSettings Validation: Requested build target group (16) doesn't exist; #define symbols for scripting won't be added.`

This PR fixes these errors by checking each BuildTargetGroup enum value for the Obsolete attribute before trying to set any scripting defines.