### PR TITLE
Add ITypeEqualityComparer to override equality checks.

### DIFF
--- a/Addons/Entitas.Unity.VisualDebugging/Assets/Entitas.Unity.VisualDebugging/Entity/Editor/TypeEqualityComparer.meta
+++ b/Addons/Entitas.Unity.VisualDebugging/Assets/Entitas.Unity.VisualDebugging/Entity/Editor/TypeEqualityComparer.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 4e87f0dc026740343807612c725594e1
+folderAsset: yes
+timeCreated: 1487233295
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Addons/Entitas.Unity.VisualDebugging/Assets/Entitas.Unity.VisualDebugging/Entity/Editor/TypeEqualityComparer/AnimationCurveTypeEqualityComparer.cs
+++ b/Addons/Entitas.Unity.VisualDebugging/Assets/Entitas.Unity.VisualDebugging/Entity/Editor/TypeEqualityComparer/AnimationCurveTypeEqualityComparer.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace Entitas.Unity.VisualDebugging {
+
+    // AnimationCurve.Equals only returns true if value and otherValue are the same reference
+    public class AnimationCurveTypeEqualityComparer : ITypeEqualityComparer {
+
+        public bool HandlesType(Type type) {
+            return type == typeof(AnimationCurve);
+        }
+
+        public bool Equals(object x, object y) {
+            if(x == y) {
+                return true;
+            }
+
+            var animationCurve = (AnimationCurve)x;
+            var otherAnimationCurve = (AnimationCurve)y;
+
+            return animationCurve.length == otherAnimationCurve.length
+               && animationCurve.preWrapMode == otherAnimationCurve.preWrapMode
+               && animationCurve.postWrapMode == otherAnimationCurve.postWrapMode
+               && ArrayUtility.ArrayEquals(animationCurve.keys, otherAnimationCurve.keys);
+        }
+    }
+}

--- a/Addons/Entitas.Unity.VisualDebugging/Assets/Entitas.Unity.VisualDebugging/Entity/Editor/TypeEqualityComparer/AnimationCurveTypeEqualityComparer.cs.meta
+++ b/Addons/Entitas.Unity.VisualDebugging/Assets/Entitas.Unity.VisualDebugging/Entity/Editor/TypeEqualityComparer/AnimationCurveTypeEqualityComparer.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: cc612dec14ab431439e03ee12a510cf5
+timeCreated: 1487236909
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Addons/Entitas.Unity.VisualDebugging/Assets/Entitas.Unity.VisualDebugging/Entity/Editor/TypeEqualityComparer/ITypeEqualityComparer.cs
+++ b/Addons/Entitas.Unity.VisualDebugging/Assets/Entitas.Unity.VisualDebugging/Entity/Editor/TypeEqualityComparer/ITypeEqualityComparer.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Entitas.Unity.VisualDebugging {
+
+    public interface ITypeEqualityComparer {
+
+        bool HandlesType(Type type);
+
+        bool Equals(object x, object y);
+    }
+}

--- a/Addons/Entitas.Unity.VisualDebugging/Assets/Entitas.Unity.VisualDebugging/Entity/Editor/TypeEqualityComparer/ITypeEqualityComparer.cs.meta
+++ b/Addons/Entitas.Unity.VisualDebugging/Assets/Entitas.Unity.VisualDebugging/Entity/Editor/TypeEqualityComparer/ITypeEqualityComparer.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 96527589ea4f20f4ca79779120c8752c
+timeCreated: 1487233449
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Some types do not correctly check for deep equality. If one of those
types is used as a component the visual debugger's inspector will not be
able to understand whether a change was applied. An example of this is
Unity's `AnimationCurve`.

This change adds a new interface type to declare type equality comparers
which are used instead of calling `Equals` on the values when changing
something in the inspector in Unity. An implementation of a type
equality comparer for `AnimationCurve` is provided, too.