### PR TITLE
Use toString on subclassed components, too.

### DIFF
--- a/Entitas/Entitas/Entity/Entity.cs
+++ b/Entitas/Entitas/Entity/Entity.cs
@@ -414,7 +414,7 @@ namespace Entitas {
                     var component = components[i];
                     var type = component.GetType();
                     var implementsToString = type.GetMethod("ToString")
-                                                 .DeclaringType == type;
+                                                 .DeclaringType.ImplementsInterface<IComponent>();
                     _toStringBuilder.Append(
                         implementsToString
                             ? component.ToString()


### PR DESCRIPTION
`Entity` uses the components' `toString` methods to build its own
description. This change makes sure to use the `toString` method of
components even if it's only declared on superclasses.