### PR TITLE
Contexts Reset

### DIFF
--- a/Addons/Entitas.CodeGenerator/Entitas.CodeGenerator/Generators/ContextsGenerator.cs
+++ b/Addons/Entitas.CodeGenerator/Entitas.CodeGenerator/Generators/ContextsGenerator.cs
@@ -41,6 +41,13 @@ ${contextAssignments}
 
 ${contextObservers}
     }
+
+    public void Reset() {
+        IContext[] contexts = allContexts;
+        for (int i = 0; i < contexts.Length; i++) {
+            contexts[i].Reset();
+        }
+    }
 }
 ";
 

--- a/Addons/Entitas.CodeGenerator/Entitas.CodeGenerator/Generators/ContextsGenerator.cs
+++ b/Addons/Entitas.CodeGenerator/Entitas.CodeGenerator/Generators/ContextsGenerator.cs
@@ -43,7 +43,7 @@ ${contextObservers}
     }
 
     public void Reset() {
-        IContext[] contexts = allContexts;
+        Entitas.IContext[] contexts = allContexts;
         for (int i = 0; i < contexts.Length; i++) {
             contexts[i].Reset();
         }

--- a/Entitas/Entitas/Context/Context.cs
+++ b/Entitas/Entitas/Context/Context.cs
@@ -305,10 +305,9 @@ namespace Entitas {
             }
         }
 
-        /// Resets the context (clears all groups, destroys all entities and
+        /// Resets the context (destroys all entities and
         /// resets creationIndex back to 0).
         public void Reset() {
-            ClearGroups();
             DestroyAllEntities();
             ResetCreationIndex();
 


### PR DESCRIPTION
Removed ClearGroups from Context.Reset() and also added a Reset() method of the Contexts class which calls reset on all the contexts in the game

This came out of our discussion about proper resetting of a game :)

https://github.com/sschmid/Entitas-CSharp/issues/310