### PR TITLE
Ignore indexed properties in component generation and entity drawer

### DIFF
--- a/Entitas/Entitas/Utils/PublicMemberInfo/PublicMemberInfoExtension.cs
+++ b/Entitas/Entitas/Utils/PublicMemberInfo/PublicMemberInfoExtension.cs
@@ -21,7 +21,7 @@ namespace Entitas {
 
             for(int i = 0; i < propertyInfos.Length; i++) {
                 var propertyInfo = propertyInfos[i];
-                if(propertyInfo.CanRead && propertyInfo.CanWrite) {
+                if(propertyInfo.CanRead && propertyInfo.CanWrite && propertyInfo.GetIndexParameters().Length == 0) {
                     memberInfos.Add(new PublicMemberInfo(propertyInfo));
                 }
             }


### PR DESCRIPTION
Indexed properties return error on _propertyInfo.GetValue(obj, null) call. It's possible to call it with indexes but resulting data doesn't make sense and be in format "Item SomeValue".

Entity\context generator generates assignment of form 'component.Item = value' and this is invalid assignment.