### PR TITLE
Fix context test: p is p -> c is ctx.

### DIFF
--- a/Tests/Tests/Tests/Entitas/describe_Context.cs
+++ b/Tests/Tests/Tests/Entitas/describe_Context.cs
@@ -216,10 +216,10 @@ class describe_Context : nspec {
 
             it["dispatches OnEntityCreated when creating a new entity"] = () => {
                 IEntity eventEntity = null;
-                ctx.OnEntityCreated += (p, entity) => {
+                ctx.OnEntityCreated += (c, entity) => {
                     didDispatch += 1;
                     eventEntity = entity;
-                    p.should_be_same(p);
+                    c.should_be_same(ctx);
                 };
 
                 var e = ctx.CreateEntity();


### PR DESCRIPTION
Looks like a small typo got in when changing `pool` to `context`.
Now the test actually tests that the first param is the context.