### PR TITLE
Ignoring .vs/ folder created by Visual Studio (for Windows)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ bin
 *.user
 test-results
 
+# Visual Studio
+.vs
+
 # Visual Studio Code
 .vscode
 


### PR DESCRIPTION
Visual Studio for Windows (not VS Code or VS for Mac) makes a .vs folder with some temp garbage in it.  So it needs to be ignored, so that `git status` is empty.