### PR TITLE
System dependencies 

### DIFF
--- a/Entitas/Entitas.csproj
+++ b/Entitas/Entitas.csproj
@@ -41,6 +41,7 @@
     <Compile Include="Entitas\Entity\Entity.cs" />
     <Compile Include="Entitas\Group\Group.cs" />
     <Compile Include="Entitas\Context\Context.cs" />
+    <Compile Include="Entitas\Systems\Interfaces\IHasSystemDependency.cs" />
     <Compile Include="Entitas\Systems\Systems.cs" />
     <Compile Include="Entitas\Systems\ReactiveSystem.cs" />
     <Compile Include="Entitas\Group\GroupEvent.cs" />

--- a/Entitas/Entitas/Systems/Interfaces/IHasSystemDependency.cs
+++ b/Entitas/Entitas/Systems/Interfaces/IHasSystemDependency.cs
@@ -1,0 +1,9 @@
+﻿namespace Entitas
+{
+    /// Implement this interface to have dependencies to another systems
+    /// that live in the same system parent
+    /// The [Systems] class is resolving the dependencies
+    public interface IHasSystemDependency<T> : ISystem where T : ISystem {
+        void SetSystem(T dependency);
+    }
+}

--- a/Entitas/Entitas/Systems/Systems.cs
+++ b/Entitas/Entitas/Systems/Systems.cs
@@ -1,8 +1,5 @@
 using System;
-using System.Reflection;
 using System.Collections.Generic;
-using System.Linq;
-using Entitas.Utils;
 
 namespace Entitas {
 

--- a/Entitas/Entitas/Systems/Systems.cs
+++ b/Entitas/Entitas/Systems/Systems.cs
@@ -56,7 +56,7 @@ namespace Entitas {
         /// Will try to resolve dependencies for elements in the _systems List  
         /// Should be called before the Initialize method so the systems can operate with
         /// the dependencies assigned
-        public virtual void SetupDependecies() {
+        public virtual void SetupDependencies() {
             for (int i = 0; i < _systems.Count; i++) {
                 for (int j = 0; j < _systems.Count; j++) {
                     var dependency = _systems[j];

--- a/Entitas/Entitas/Systems/Systems.cs
+++ b/Entitas/Entitas/Systems/Systems.cs
@@ -78,7 +78,7 @@ namespace Entitas {
         }
 
         /// Request a system from the _systems List
-        public virtual T GetSystem<T>()
+        public virtual T GetSystem<T>() where T : ISystem
         {
             return (T)_systems.Find(s => s is T);
         }

--- a/Tests/Tests/Fixtures/Systems/HasDependencySystemSpy.cs
+++ b/Tests/Tests/Fixtures/Systems/HasDependencySystemSpy.cs
@@ -1,0 +1,20 @@
+﻿using Entitas;
+
+public class HasDependencySystemSpy :
+    // Can implement any ISystem interface
+    IHasSystemDependency<InitializeSystemSpy>,
+    IHasSystemDependency<TearDownSystemSpy> {
+
+    public int teardownSystemDeps { private set; get; }
+    public int initialiseSystemDeps { private set; get; }
+
+    public void SetSystem(InitializeSystemSpy dependency)
+    {
+        initialiseSystemDeps ++;
+    }
+    
+    public void SetSystem(TearDownSystemSpy dependency)
+    {
+        teardownSystemDeps ++;
+    }
+}

--- a/Tests/Tests/Tests.csproj
+++ b/Tests/Tests/Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -40,6 +40,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Fixtures\Systems\HasDependencySystemSpy.cs" />
     <Compile Include="Tests\TestExtensions.cs" />
     <Compile Include="Tests\check_namespaces.cs" />
     <Compile Include="TestRunner.cs" />

--- a/Tests/Tests/Tests/Entitas/describe_Systems.cs
+++ b/Tests/Tests/Tests/Entitas/describe_Systems.cs
@@ -304,12 +304,12 @@ class describe_Systems : nspec {
                 var parentSystems = new Systems();
                 parentSystems.Add(teardownSystem).Add(initializeSystem).Add(hasDependenciesSystem);
 
-                parentSystems.SetupDependecies();
+                parentSystems.SetupDependencies();
 
                 hasDependenciesSystem.initialiseSystemDeps.should_be(1);
                 hasDependenciesSystem.teardownSystemDeps.should_be(1);
 
-                parentSystems.SetupDependecies();
+                parentSystems.SetupDependencies();
 
                 hasDependenciesSystem.initialiseSystemDeps.should_be(2);
                 hasDependenciesSystem.teardownSystemDeps.should_be(2);

--- a/Tests/Tests/Tests/Entitas/describe_Systems.cs
+++ b/Tests/Tests/Tests/Entitas/describe_Systems.cs
@@ -295,6 +295,48 @@ class describe_Systems : nspec {
 
                 system.didExecute.should_be(1);
             };
+
+            it["setup dependencies for systems"] = () => {
+                var initializeSystem = new InitializeSystemSpy();
+                var teardownSystem = new TearDownSystemSpy();
+                var hasDependenciesSystem = new HasDependencySystemSpy();
+
+                var parentSystems = new Systems();
+                parentSystems.Add(teardownSystem).Add(initializeSystem).Add(hasDependenciesSystem);
+
+                parentSystems.SetupDependecies();
+
+                hasDependenciesSystem.initialiseSystemDeps.should_be(1);
+                hasDependenciesSystem.teardownSystemDeps.should_be(1);
+
+                parentSystems.SetupDependecies();
+
+                hasDependenciesSystem.initialiseSystemDeps.should_be(2);
+                hasDependenciesSystem.teardownSystemDeps.should_be(2);
+            };
+
+            it["get system from system parent"] = () =>
+            {
+                var parentSystems = new Systems();
+                parentSystems.Add(new TearDownSystemSpy()).Add(new InitializeSystemSpy());
+
+                var initializeSystem = parentSystems.GetSystem<InitializeSystemSpy>();
+                initializeSystem.should_not_be_null();
+
+                var teardownSystem = parentSystems.GetSystem<TearDownSystemSpy>();
+                teardownSystem.should_not_be_null();
+            };
+            
+            it["get null object if requesting a system that is not added to a parent"] = () => {
+                var parentSystems = new Systems();
+                parentSystems.Add(new InitializeSystemSpy());
+
+                var initializeSystem = parentSystems.GetSystem<InitializeSystemSpy>();
+                initializeSystem.should_not_be_null();
+                
+                var teardownSystem = parentSystems.GetSystem<TearDownSystemSpy>();
+                teardownSystem.should_be_null();
+            };
         };
     }
 }


### PR DESCRIPTION
Add the possibility to have dependencies between systems of the same parent.
The 'Systems' class will resolve and assign the dependencies to every class that implements the IHasSystemDependency interface by calling the 'SetupDependecies' method.

The method should be called before the 'Initialize' so systems can operate with dependencies assigned.