### PR TITLE
Added support for deeper Unity profiler.

### DIFF
--- a/Addons/Entitas.VisualDebugging.CodeGeneration.Plugins/Entitas.VisualDebugging.CodeGeneration.Plugins/Plugins/FeatureClassGenerator.cs
+++ b/Addons/Entitas.VisualDebugging.CodeGeneration.Plugins/Entitas.VisualDebugging.CodeGeneration.Plugins/Plugins/FeatureClassGenerator.cs
@@ -26,6 +26,96 @@ public class Feature : Entitas.VisualDebugging.Unity.DebugSystems {
     }
 }
 
+#elif (!ENTITAS_DISABLE_PROFILING && DEVELOPMENT_BUILD)
+
+public class Feature : Entitas.Systems
+{
+    private System.Collections.Generic.List<string> _initializeSystemNames;
+    private System.Collections.Generic.List<string> _executeSystemNames;
+    private System.Collections.Generic.List<string> _cleanupSystemNames;
+    private System.Collections.Generic.List<string> _tearDownSystemNames;
+
+    public Feature(string name) : this()
+    {
+    }
+
+    public Feature()
+    {
+        _initializeSystemNames = new System.Collections.Generic.List<string>();
+        _executeSystemNames = new System.Collections.Generic.List<string>();
+        _cleanupSystemNames = new System.Collections.Generic.List<string>();
+        _tearDownSystemNames = new System.Collections.Generic.List<string>();
+    }
+
+    public override Entitas.Systems Add(Entitas.ISystem system)
+    {
+        var systemName = system.GetType().Name;
+
+        if (system is Entitas.IInitializeSystem)
+        {
+            _initializeSystemNames.Add(systemName);
+        }
+        if (system is Entitas.IExecuteSystem)
+        {
+            _executeSystemNames.Add(systemName);
+        }
+        if (system is Entitas.ITearDownSystem)
+        {
+            _tearDownSystemNames.Add(systemName);
+        }
+        if (system is Entitas.ITearDownSystem)
+        {
+            _tearDownSystemNames.Add(systemName);
+        }
+        if (system is Entitas.ICleanupSystem)
+        {
+            _cleanupSystemNames.Add(systemName);
+        }
+
+        return base.Add(system);
+    }
+
+    public override void Initialize()
+    {
+        for (int i = 0; i < _initializeSystems.Count; i++)
+        {
+            UnityEngine.Profiling.Profiler.BeginSample(_initializeSystemNames[i]);
+            _initializeSystems[i].Initialize();
+            UnityEngine.Profiling.Profiler.EndSample();
+        }
+    }
+
+    public override void Execute()
+    {
+        for (int i = 0; i < _executeSystems.Count; i++)
+        {
+            UnityEngine.Profiling.Profiler.BeginSample(_executeSystemNames[i]);
+            _executeSystems[i].Execute();
+            UnityEngine.Profiling.Profiler.EndSample();
+        }
+    }
+
+    public override void Cleanup()
+    {
+        for (int i = 0; i < _cleanupSystems.Count; i++)
+        {
+            UnityEngine.Profiling.Profiler.BeginSample(_cleanupSystemNames[i]);
+            _cleanupSystems[i].Cleanup();
+            UnityEngine.Profiling.Profiler.EndSample();
+        }
+    }
+
+    public override void TearDown()
+    {
+        for (int i = 0; i < _tearDownSystems.Count; i++)
+        {
+            UnityEngine.Profiling.Profiler.BeginSample(_tearDownSystemNames[i]);
+            _tearDownSystems[i].TearDown();
+            UnityEngine.Profiling.Profiler.EndSample();
+        }
+    }
+}
+
 #else
 
 public class Feature : Entitas.Systems {


### PR DESCRIPTION
Added support for deeper on-device Unit Profiling. It requires to store the whole class as source because of the conditional compilation of the `Profiler.BeginSample()` and `Profiler.EndSample()` calls which don't compile at all if compilation is done ahead of time outside of Unity Editor

Profiling is automatically enabled when building a "Development build" and can be turned off with the `ENTITAS_DISABLE_PROFILING` compiler conditional.

It requires regenerating code after the project update so changes land to the `Feature.cs` file