### PR TITLE
Corrected message of ContextStillHasRetainedEntitiesException

### DIFF
--- a/Entitas/Entitas/Context/Exceptions/ContextStillHasRetainedEntitiesException.cs
+++ b/Entitas/Entitas/Context/Exceptions/ContextStillHasRetainedEntitiesException.cs
@@ -7,8 +7,9 @@ namespace Entitas {
         public ContextStillHasRetainedEntitiesException(IContext context, IEntity[] entities)
             : base("'" + context + "' detected retained entities " +
                    "although all entities got destroyed!",
-                "Did you release all entities? Try calling systems.ClearReactiveSystems()" +
-                "before calling context.DestroyAllEntities() to avoid memory leaks.\n" +
+                "Did you release all entities? Try calling systems.DeactivateReactiveSystems()" +
+                "before calling context.DestroyAllEntities() to avoid memory leaks." +
+                "Do not forget to activate them back when needed.\n" +
                 string.Join("\n", entities
                     .Select(e => {
                         var safeAerc = e.aerc as SafeAERC;


### PR DESCRIPTION
Initial message considered to call `systems.ClearReactiveSystems()` method which actually did not do the trick because reactive systems still retained references to entities. However `systems.DeactivateReactiveSystems()` does the expected behavior, so I updated exception message correspondingly.