### PR TITLE
Handle duplicate context attributes for a component by throwing an exception

### DIFF
--- a/Addons/Entitas.CodeGeneration.Plugins/Entitas.CodeGeneration.Plugins/Plugins/DataProviders/Components/Providers/ContextsComponentDataProvider.cs
+++ b/Addons/Entitas.CodeGeneration.Plugins/Entitas.CodeGeneration.Plugins/Plugins/DataProviders/Components/Providers/ContextsComponentDataProvider.cs
@@ -18,6 +18,18 @@ namespace Entitas.CodeGeneration.Plugins {
 
         public void Provide(Type type, ComponentData data) {
             var contextNames = GetContextNamesOrDefault(type);
+
+            if (contextNames.Distinct().ToArray().Length != contextNames.Length) {
+                var duplicatedContextNames = contextNames.GroupBy(_ => _)
+                    .Where(n => n.Count() > 1)
+                    .Select(n => n.Key).ToArray();
+                var duplicateContexts = string.Join(", ", duplicatedContextNames);
+                    
+                throw new EntitasException(
+                    "Duplicate context attributes defined for component '" + type.Name + "'",
+                    "The duplicate context names are: " + duplicateContexts);
+            }
+
             data.SetContextNames(contextNames);
         }
 

--- a/Tests/Tests.Fixtures/Fixtures/Components/ComponentWithDuplicatedContexts.cs
+++ b/Tests/Tests.Fixtures/Fixtures/Components/ComponentWithDuplicatedContexts.cs
@@ -1,0 +1,10 @@
+﻿using Entitas;
+using Entitas.CodeGeneration.Attributes;
+
+namespace My.Namespace {
+
+    [Context("Test"), Context("Test")]
+    public sealed class ComponentWithDuplicatedContexts : IComponent {
+        public string value;
+    }
+}

--- a/Tests/Tests.Fixtures/Tests.Fixtures.csproj
+++ b/Tests/Tests.Fixtures/Tests.Fixtures.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -31,6 +31,7 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Fixtures\Components\ComponentWithDuplicatedContexts.cs" />
     <Compile Include="Generated\Test\Components\TestCustomPrefixFlagComponent.cs" />
     <Compile Include="Generated\Test\Components\TestUniqueFlagComponent.cs" />
     <Compile Include="Generated\Test\Components\TestUniqueStandardComponent.cs" />

--- a/Tests/Tests/Tests.csproj
+++ b/Tests/Tests/Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -40,6 +40,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Tests\Entitas.CodeGeneration\DataProviders\describe_ContextComponentDataProvider.cs" />
     <Compile Include="Tests\TestExtensions.cs" />
     <Compile Include="Tests\check_namespaces.cs" />
     <Compile Include="TestRunner.cs" />

--- a/Tests/Tests/Tests/Entitas.CodeGeneration/DataProviders/describe_ContextComponentDataProvider.cs
+++ b/Tests/Tests/Tests/Entitas.CodeGeneration/DataProviders/describe_ContextComponentDataProvider.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Entitas;
+using Entitas.CodeGeneration.Plugins;
+using Entitas.Utils;
+using My.Namespace;
+using NSpec;
+
+class describe_ContextComponentDataProvider : nspec {
+
+    ComponentData getData<T>(Properties properties = null) {
+        return getMultipleData<T>(properties)[0];
+    }
+
+    ComponentData[] getMultipleData<T>(Properties properties = null) {
+        var provider = new ComponentDataProvider(new Type[] { typeof(T) });
+        if (properties == null) {
+            properties = new Properties("Entitas.CodeGeneration.Plugins.Contexts = Game, GameState");
+        }
+        provider.Configure(properties);
+
+        return (ComponentData[])provider.GetData();
+    }
+
+    void when_providing() {
+
+        context["context names"] = () => {
+            
+            it["when no contexts are specified"] = () => {
+                var data = getData<NoContextComponent>();
+
+                data.GetContextNames().Length.should_be(1);
+            };
+            
+            it["when contexts are specified"] = () => {
+                var data = getData<NameAgeComponent>();
+
+                data.GetContextNames().Length.should_be(2);
+                data.GetContextNames().should_contain("Test");
+                data.GetContextNames().should_contain("Test2");
+            };
+            
+            context["fail"] = () => {
+                it["when there are duplicate context attributes specified"] = () => {                
+                    expect<EntitasException>(() => getData<ComponentWithDuplicatedContexts>());
+                };
+            };
+        };
+    }
+}


### PR DESCRIPTION
When defining duplicate context attributes for a component, code generation results in duplicates of code snippets.

To prevent this unexpected behaviour, throw an exception notifying the user with the component name and duplicate contexts so they can fix the issue.