### PR TITLE
Feature/inspector generic names

### DIFF
--- a/Addons/Entitas.VisualDebugging.Unity.Editor/Entitas.VisualDebugging.Unity.Editor/Entity/Entity/EntityDrawer.cs
+++ b/Addons/Entitas.VisualDebugging.Unity.Editor/Entitas.VisualDebugging.Unity.Editor/Entity/Entity/EntityDrawer.cs
@@ -165,8 +165,9 @@ namespace Entitas.VisualDebugging.Unity.Editor
         {
             var componentType = component.GetType();
             var customNameProvider = component as ICustomDisplayName;
-            var componentName = customNameProvider?.DisplayName 
-                ?? TypeHelper.GetTypeName(componentType).RemoveComponentSuffix();
+            var componentName = customNameProvider != null
+                ? customNameProvider.DisplayName
+                : TypeHelper.GetTypeName(componentType).RemoveComponentSuffix();                
 
             if (EditorLayout.MatchesSearchString(componentName.ToLower(), componentNameSearchString.ToLower()))
             {

--- a/Addons/Entitas.VisualDebugging.Unity.Editor/Entitas.VisualDebugging.Unity.Editor/Entity/Entity/EntityDrawer.cs
+++ b/Addons/Entitas.VisualDebugging.Unity.Editor/Entitas.VisualDebugging.Unity.Editor/Entity/Entity/EntityDrawer.cs
@@ -164,7 +164,10 @@ namespace Entitas.VisualDebugging.Unity.Editor
         public static void DrawComponent(bool[] unfoldedComponents, string[] componentMemberSearch, IEntity entity, int index, IComponent component)
         {
             var componentType = component.GetType();
-            var componentName = componentType.Name.RemoveComponentSuffix();
+            var customNameProvider = component as ICustomDisplayName;
+            var componentName = customNameProvider?.DisplayName 
+                ?? TypeHelper.GetTypeName(componentType).RemoveComponentSuffix();
+
             if (EditorLayout.MatchesSearchString(componentName.ToLower(), componentNameSearchString.ToLower()))
             {
                 var boxStyle = getColoredBoxStyle(entity, index);

--- a/Addons/Entitas.VisualDebugging.Unity/Entitas.VisualDebugging.Unity.csproj
+++ b/Addons/Entitas.VisualDebugging.Unity/Entitas.VisualDebugging.Unity.csproj
@@ -44,6 +44,8 @@
     <Compile Include="Entitas.VisualDebugging.Unity\Entity\DontDrawComponentAttribute.cs" />
     <Compile Include="Entitas.VisualDebugging.Unity\Entity\EntityBehaviour.cs" />
     <Compile Include="Entitas.VisualDebugging.Unity\GameObjectDestroyExtension.cs" />
+    <Compile Include="Entitas.VisualDebugging.Unity\ICustomDisplayName.cs" />
+    <Compile Include="Entitas.VisualDebugging.Unity\TypeHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Entitas\Entitas.csproj">
@@ -51,8 +53,6 @@
       <Name>Entitas</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Entitas.VisualDebugging.Unity\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Addons/Entitas.VisualDebugging.Unity/Entitas.VisualDebugging.Unity/DebugSystems/SystemInfo.cs
+++ b/Addons/Entitas.VisualDebugging.Unity/Entitas.VisualDebugging.Unity/DebugSystems/SystemInfo.cs
@@ -62,9 +62,16 @@ namespace Entitas.VisualDebugging.Unity {
             _interfaceFlags = getInterfaceFlags(system);
 
             var debugSystem = system as DebugSystems;
-            _systemName = debugSystem != null
-                ? debugSystem.name
-                : system.GetType().Name.RemoveSystemSuffix();
+            if (debugSystem != null)
+            {
+                _systemName = debugSystem.name;
+            }
+            else
+            {
+                var customNameProvider = system as ICustomDisplayName;
+                _systemName = customNameProvider?.DisplayName
+                    ?? TypeHelper.GetTypeName(system.GetType()).RemoveSystemSuffix();
+            }
 
             isActive = true;
         }

--- a/Addons/Entitas.VisualDebugging.Unity/Entitas.VisualDebugging.Unity/DebugSystems/SystemInfo.cs
+++ b/Addons/Entitas.VisualDebugging.Unity/Entitas.VisualDebugging.Unity/DebugSystems/SystemInfo.cs
@@ -69,8 +69,14 @@ namespace Entitas.VisualDebugging.Unity {
             else
             {
                 var customNameProvider = system as ICustomDisplayName;
-                _systemName = customNameProvider?.DisplayName
-                    ?? TypeHelper.GetTypeName(system.GetType()).RemoveSystemSuffix();
+                if (customNameProvider != null)
+                {
+                    _systemName = customNameProvider.DisplayName;
+                }
+                else
+                {
+                    _systemName = TypeHelper.GetTypeName(system.GetType()).RemoveSystemSuffix();
+                }
             }
 
             isActive = true;

--- a/Addons/Entitas.VisualDebugging.Unity/Entitas.VisualDebugging.Unity/ICustomDisplayName.cs
+++ b/Addons/Entitas.VisualDebugging.Unity/Entitas.VisualDebugging.Unity/ICustomDisplayName.cs
@@ -1,0 +1,7 @@
+﻿namespace Entitas.VisualDebugging.Unity
+{
+    public interface ICustomDisplayName
+    {
+        string DisplayName { get; }
+    }
+}

--- a/Addons/Entitas.VisualDebugging.Unity/Entitas.VisualDebugging.Unity/TypeHelper.cs
+++ b/Addons/Entitas.VisualDebugging.Unity/Entitas.VisualDebugging.Unity/TypeHelper.cs
@@ -13,12 +13,16 @@ namespace Entitas.VisualDebugging.Unity
             {
                 var simpleName = type.Name.Substring(0, type.Name.IndexOf('`'));
                 string genericTypeParams = string.Empty;
-                for (int i = 0; i < type.GenericTypeArguments.Length; i++)
+                var args = !type.IsGenericTypeDefinition
+                    ? type.GetGenericArguments()
+                    : Type.EmptyTypes;
+
+                for (int i = 0; i < args.Length; i++)
                 {
                     if (i > 0) genericTypeParams += ",";
-                    genericTypeParams += GetTypeName(type.GenericTypeArguments[i]);
+                    genericTypeParams += GetTypeName(args[i]);
                 }
-                return string.Format("{0}<{1}>", simpleName, string.Join(", ", genericTypeParams));
+                return string.Format("{0}<{1}>", simpleName, genericTypeParams);
             }
             return type.Name;
         }

--- a/Addons/Entitas.VisualDebugging.Unity/Entitas.VisualDebugging.Unity/TypeHelper.cs
+++ b/Addons/Entitas.VisualDebugging.Unity/Entitas.VisualDebugging.Unity/TypeHelper.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace Entitas.VisualDebugging.Unity
+{
+    public static class TypeHelper
+    {
+        /// <summary>
+        /// Returns a type name including generic type parameters.
+        /// </summary>
+        public static string GetTypeName(Type type)
+        {
+            if (type.IsGenericType)
+            {
+                var simpleName = type.Name.Substring(0, type.Name.IndexOf('`'));
+                string genericTypeParams = string.Empty;
+                for (int i = 0; i < type.GenericTypeArguments.Length; i++)
+                {
+                    if (i > 0) genericTypeParams += ",";
+                    genericTypeParams += GetTypeName(type.GenericTypeArguments[i]);
+                }
+                return string.Format("{0}<{1}>", simpleName, string.Join(", ", genericTypeParams));
+            }
+            return type.Name;
+        }
+    }
+}


### PR DESCRIPTION
- Systems/Components with generic type parameters correctly display the full type name in the inspector.

<img src="https://i.imgur.com/ONLjmEN.png"/>
<img src="https://i.imgur.com/3xyfQiF.png"/>

- Systems/Components implementing ICustomDisplayName show in the inspector with the user-provided name.

<img src="https://i.imgur.com/8rD23e4.png"/>
<img src="https://i.imgur.com/XVauwH5.png"/>

This is what generic names currently look like.

<img src="https://i.imgur.com/jzIireX.png"/>
<img src="https://i.imgur.com/XTfCvHq.png"/>